### PR TITLE
Added requiresMainQueueSetup

### DIFF
--- a/RCTPrivacySnapshot/RCTPrivacySnapshot.m
+++ b/RCTPrivacySnapshot/RCTPrivacySnapshot.m
@@ -14,6 +14,11 @@
     UIImageView *obfuscatingView;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_MODULE();
 
 #pragma mark - Lifecycle

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-privacy-snapshot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Obscure passwords and other sensitive personal information when a react-native app transitions to the background",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Fixes warning:

"Module RCTPrivacySanpshot requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of."